### PR TITLE
feat: Pass any remaining props to the adsense block

### DIFF
--- a/src/adsense.tsx
+++ b/src/adsense.tsx
@@ -22,6 +22,7 @@ export const Adsense = ({
   format = 'auto',
   responsive = 'false',
   pageLevelAds = false,
+  ...rest
 }: Props) => {
   useEffect(() => {
     const p: any = {};
@@ -50,6 +51,7 @@ export const Adsense = ({
       data-ad-layout-key={layoutKey}
       data-ad-format={format}
       data-full-width-responsive={responsive}
+      {...rest}
     />
   );
 };


### PR DESCRIPTION
I was having trouble (and still am loL) getting ads to show on localhost or on staging — so I tried adding `data-adtest="true"` to the component but noticed props weren't being passed!

Something like the changes in this PR could help this lib not have to keep up-to-date with all the `data-` props supported by adsense
